### PR TITLE
Implement getQueueAttributes

### DIFF
--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -59,6 +59,23 @@ var SQS = function(accessKeyId, secretAccessKey, opts) {
 };
 
 /**
+ * Create an SQSClient 
+ * @param {?string} [version] WSDL version to use
+ * @param {string} [path] Path of the queue to connect to
+ * @returns {awsjs.SQSClient}
+ */
+SQS.prototype._createClient = function (version, path) {
+  var params = { host : this.host, secure: true };
+  if (version) params.version = version;
+  if (path) params.path = path;
+
+  return awsjs.createSQSClient(
+    this.accessKeyId,
+    this.secretAccessKey,
+    params);
+}
+
+/**
  * Create a SQS queue
  * @param  {string} name The name of the queue
  *   Constraints: Maximum 80 characters; alphanumeric characters, hyphens (-),
@@ -116,14 +133,7 @@ SQS.prototype.createQueue = function(name, attrs, fn) {
   }
 
   var host = this.host;
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      secure: true,
-      version: '2011-10-01'
-  });
+  var aws = this._createClient('2011-10-01');
 
   makeCall(aws, 'CreateQueue', params, function(err, result) {
     var url = '';
@@ -147,14 +157,7 @@ SQS.prototype.createQueue = function(name, attrs, fn) {
  * @link SQS.prototype.createQueue
  */
 SQS.prototype.deleteQueue = function(name, fn) {
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      path : name,
-      secure: true
-  });
+  var aws = this._createClient('2011-10-01', name);
 
   makeCall(aws, 'DeleteQueue', {}, function(err, result) {
     fn(err);
@@ -170,14 +173,7 @@ SQS.prototype.deleteQueue = function(name, fn) {
  * @link SQS.prototype.listQueues
  */
 SQS.prototype.getQueueUrl = function(name, fn) {
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      secure: true,
-      version: '2011-10-01'
-  });
+  var aws = this._createClient('2011-10-01');
   var params = {
     QueueName : name
   };
@@ -207,14 +203,7 @@ SQS.prototype.listQueues = function(prefix, fn) {
 
   var host = this.host;
 
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      secure: true,
-      version: '2011-10-01'
-  });
+  var aws = this._createClient('2011-10-01');
 
   var params = {};
   if(prefix) {
@@ -258,14 +247,7 @@ SQS.prototype.sendMessage = function(queue, message, delay, fn) {
     delay = null;
   }
 
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      path : queue,
-      secure: true
-  });
+  var aws = this._createClient(null, queue);
 
   var params = {
     MessageBody : message
@@ -300,15 +282,7 @@ SQS.prototype.sendMessage = function(queue, message, delay, fn) {
  * @link SQS.prototype.sendMessage
  */
 SQS.prototype.sendMessageBatch = function(queue, messages, fn) {
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      path : queue,
-      secure: true,
-      version: '2011-10-01'
-  });
+  var aws = this._createClient('2011-10-01', queue);
 
   var params = {};
 
@@ -357,14 +331,7 @@ SQS.prototype.receiveMessage = function(queue, opts, fn) {
     opts = null;
   }
 
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      path : queue,
-      secure: true
-  });
+  var aws = this._createClient(null, queue);
 
   var params = {};
 
@@ -424,14 +391,7 @@ SQS.prototype.receiveMessage = function(queue, opts, fn) {
  * @link SQS.prototype.deleteMessage
  */
 SQS.prototype.deleteMessage = function(queue, messageReceipt, fn) {
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      path : queue,
-      secure: true
-  });
+  var aws = this._createClient(null, queue);
 
   var params = {
     ReceiptHandle : messageReceipt
@@ -453,15 +413,7 @@ SQS.prototype.deleteMessage = function(queue, messageReceipt, fn) {
  * @link SQS.prototype.deleteMessageBatch
  */
 SQS.prototype.deleteMessageBatch = function(queue, messageReceipts, fn) {
-  var aws = awsjs.createSQSClient(
-    this.accessKeyId,
-    this.secretAccessKey,
-    {
-      host : this.host,
-      path : queue,
-      secure: true,
-      version: '2011-10-01'
-  });
+  var aws = this._createClient('2011-10-01', queue);
 
   var params = {};
 

--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -8,7 +8,7 @@ CreateQueue - createQueue(name, [attrs], fn)
 DeleteMessage - deleteMessage(queue, messageReceipt, fn)
 DeleteMessageBatch - deleteMessageBatch(queue, messageReceipts, fn)
 DeleteQueue - deleteQueue(name, fn)
-GetQueueAttributes
+GetQueueAttributes - getQueueAttributes(queue, [attrs], fn)
 GetQueueUrl - getQueueUrl(name, fn)
 ListQueues - listQueues([prefix], fn)
 ReceiveMessage - receiveMessage(queue, [opts], fn)
@@ -227,6 +227,60 @@ SQS.prototype.listQueues = function(prefix, fn) {
     }
     fn(err, urls);
   });
+};
+
+/**
+ * Returns attributes of a queue
+ * @param {string} queue The full name of the queue. Should be something like
+ * /12312301239/nameOfQueue.
+ * @param {?string[]} [attrs] An array of attributes to query for. If ommitted
+ * , will query for all attributes
+ * @param {Function} fn The callback for when the message is add to queue,
+ * Callback function should take two parameters, error and result which is
+ * and the message details.
+ */
+SQS.prototype.getQueueAttributes = function (queue, attrs, fn) {
+
+  var params = {};
+
+  if (typeof(attrs) === 'function') {
+    fn = attrs;
+  }
+
+  if (!Array.isArray(attrs) || attrs.length < 1) {
+    attrs = ['All'];
+  }
+
+  for(var i = 1, len = attrs.length; i <= len; i++) {
+    params['AttributeName.'  + i] = attrs[i-1];
+  }
+
+  var aws = this._createClient('2011-10-01', queue);
+
+  makeCall(aws, 'GetQueueAttributes', params, function (err, result) {
+    var ret = null;
+    if (!err &&
+      result.GetQueueAttributesResult && 
+      result.GetQueueAttributesResult.Attribute !== null &&
+      typeof(result.GetQueueAttributesResult.Attribute) === 'object') 
+    {
+      ret = {};
+      if (Array.isArray(result.GetQueueAttributesResult.Attribute)) {
+        result.GetQueueAttributesResult.Attribute.forEach(function (attr) {
+          if (typeof(attr) === 'object' && 
+            attr !== null && 
+            typeof(attr.Name) === 'string') 
+          {
+            ret[attr.Name] = attr.Value;
+          }
+        });
+      } else if (result.GetQueueAttributesResult.Attribute.Name) {
+        ret[result.GetQueueAttributesResult.Attribute.Name] = result.GetQueueAttributesResult.Attribute.Value;
+      }
+    }
+    fn(err, ret);  
+  });
+
 };
 
 /**

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -162,6 +162,22 @@ vows.describe('Simple Queue Service').addBatch({
   'A queue' : {
     topic: new SQS(keys.id, keys.secret),
 
+    'when requesting queue attributes': {
+      topic: getQualifiedQueue('testQueue', function () {
+        this.sqs.getQueueAttributes(this.queue, this.callback);
+      }),
+
+      'results in information about the queue': function (err, result) {
+        assert.isNull(err);
+        assert.isObject(result);
+        assert.includes(result, 'ApproximateNumberOfMessages');
+      } 
+    }
+  }
+}).addBatch({
+  'A queue' : {
+    topic: new SQS(keys.id, keys.secret),
+
     'when deleting a queue': {
       topic: getQualifiedQueue('testQueue', function () {
         this.sqs.deleteQueue(this.queue, this.callback);

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -162,7 +162,7 @@ vows.describe('Simple Queue Service').addBatch({
   'A queue' : {
     topic: new SQS(keys.id, keys.secret),
 
-    'when requesting queue attributes': {
+    'when requesting all queue attributes': {
       topic: getQualifiedQueue('testQueue', function () {
         this.sqs.getQueueAttributes(this.queue, this.callback);
       }),
@@ -172,6 +172,21 @@ vows.describe('Simple Queue Service').addBatch({
         assert.isObject(result);
         assert.includes(result, 'ApproximateNumberOfMessages');
       } 
+    },
+
+    'when requesting a single attribute': {
+      topic: getQualifiedQueue('testQueue', function () {
+        this.sqs.getQueueAttributes(
+          this.queue, 
+          ['ApproximateNumberOfMessages'], 
+          this.callback);
+      }),
+
+      'results in information about that attribute': function (err, result) {
+        assert.isNull(err);
+        assert.isObject(result);
+        assert.deepEqual(Object.keys(result), ['ApproximateNumberOfMessages'])
+      }
     }
   }
 }).addBatch({


### PR DESCRIPTION
First commit is to make the `awsjs.SQSClient` creation a little more dry. I have it isolated so please let me know in case this is not ok and I'll send you a new PR.

Other commits implement Issue #7

syntax:

``` javascript
  sqs.getQueueAttributes(/*string*/ queue [, /*Array*/ attrs], /*function (err, result) */ fn );
```

where result is formatted as: `{attr-1: value-1, attr-n: value-n}`
