### PR TITLE
Allow alternate endpoints for backward compatibility

### DIFF
--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -51,11 +51,13 @@ var makeCall = function(aws, action, params, fn) {
 var SQS = function(accessKeyId, secretAccessKey, opts) {
 
   // optional parameters
-  opts = opts || {};
+  opts = (typeof(opts) === 'object' && opts !== null) ? opts : {};
   this.accessKeyId = accessKeyId;
   this.secretAccessKey = secretAccessKey;
   this.region = opts.region || 'us-east-1';
-  this.host = 'sqs.' + this.region + '.amazonaws.com';
+  this.host = ((opts.altEndPoint) ? 
+    ((this.region !== 'us-east-1') ? this.region + '.' : '') + 'queue.amazonaws.com' : 
+    'sqs.' + this.region + '.amazonaws.com');
 };
 
 /**

--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -46,6 +46,9 @@ var makeCall = function(aws, action, params, fn) {
  * @param {object} [opts] optional parameters
  * @config {string} [opts.region] the aws region, must be one of these:
  *   us-east-1, us-west-1, us-west-2, eu-west-1, ap-southeast-1, ap-northeast-1
+ * @config {boolean} [opts.altEndPoint] use alternate endpoints for backward 
+ *   compatibility: "[region.]queue.amazonaws.com", see
+ *   http://docs.aws.amazon.com/AWSSimpleQueueService/2009-02-01/SQSDeveloperGuide/index.html?endpoints.html
  * @class
  */
 var SQS = function(accessKeyId, secretAccessKey, opts) {
@@ -75,7 +78,7 @@ SQS.prototype._createClient = function (version, path) {
     this.accessKeyId,
     this.secretAccessKey,
     params);
-}
+};
 
 /**
  * Create a SQS queue

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -19,7 +19,7 @@ var getQualifiedQueue = function (name, cb) {
         cb.call(that); 
       } else that.callback(err);
     });
-  }
+  };
 };
 
 // Create a Test Suite
@@ -51,7 +51,7 @@ vows.describe('Simple Queue Service').addBatch({
   }
 }).addBatch({
   'A queue' : {
-    topic: new SQS(keys.id, keys.secret, {region: REGION, altEndPoint: true }),
+    topic: new SQS(keys.id, keys.secret, {region: REGION, altEndPoint: true}),
 
     'when creating a queue over an alternate endpoint': {
       topic: function(sqs) {
@@ -87,7 +87,7 @@ vows.describe('Simple Queue Service').addBatch({
       'results in array of queue names': function (err, result) {
         assert.isNull(err);
         assert.isArray(result);
-        assert.isTrue(result.some(function (q) { return typeof(q) === 'string' && q.match(/\/\d+\/testQueue/)}));
+        assert.isTrue(result.some(function (q) { return typeof(q) === 'string' && q.match(/\/\d+\/testQueue/); }));
       }
     },
     'when retrieving list of queues with prefix': {
@@ -98,8 +98,8 @@ vows.describe('Simple Queue Service').addBatch({
       'results in array of queue names': function (err, result) {
         assert.isNull(err);
         assert.isArray(result);
-        assert.isTrue(result.some(function (q) { return typeof(q) === 'string' && q.match(/\/\d+\/testTimeoutQueue/)}));
-        assert.isFalse(result.some(function (q) { return typeof(q) === 'string' && q.match(/\/\d+\/testQueue/)}));
+        assert.isTrue(result.some(function (q) { return typeof(q) === 'string' && q.match(/\/\d+\/testTimeoutQueue/); }));
+        assert.isFalse(result.some(function (q) { return typeof(q) === 'string' && q.match(/\/\d+\/testQueue/); }));
       }
     }
   },
@@ -205,7 +205,7 @@ vows.describe('Simple Queue Service').addBatch({
       'results in information about that attribute': function (err, result) {
         assert.isNull(err);
         assert.isObject(result);
-        assert.deepEqual(Object.keys(result), ['ApproximateNumberOfMessages'])
+        assert.deepEqual(Object.keys(result), ['ApproximateNumberOfMessages']);
       }
     }
   }

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -4,6 +4,9 @@ var vows = require('vows'),
 var keys = require('./keys');
 var SQS = require('../lib/sqs');
 
+// Statics
+var REGION = 'us-east-1';
+
 /** Helper function to get the qualified queue */
 var getQualifiedQueue = function (name, cb) {
   return function (messages, sqs) {
@@ -22,7 +25,7 @@ var getQualifiedQueue = function (name, cb) {
 // Create a Test Suite
 vows.describe('Simple Queue Service').addBatch({
   'A queue' : {
-    topic: new SQS(keys.id, keys.secret),
+    topic: new SQS(keys.id, keys.secret, {region: REGION}),
 
     'when creating a queue without attributes': {
       topic: function(sqs) {
@@ -34,6 +37,7 @@ vows.describe('Simple Queue Service').addBatch({
         assert.match(result, /\/\d+\/testQueue/);
       }
     },
+
     'when creating a queue with visibility timeout': {
       topic: function(sqs) {
         sqs.createQueue('testTimeoutQueue', {VisibilityTimeout : 120}, this.callback);
@@ -47,7 +51,23 @@ vows.describe('Simple Queue Service').addBatch({
   }
 }).addBatch({
   'A queue' : {
-    topic: new SQS(keys.id, keys.secret),
+    topic: new SQS(keys.id, keys.secret, {region: REGION, altEndPoint: true }),
+
+    'when creating a queue over an alternate endpoint': {
+      topic: function(sqs) {
+        sqs.createQueue('testAltEndpointQueue', {VisibilityTimeout : 120}, this.callback);
+      },
+
+      'results in new queue': function (err, result) {
+        assert.isNull(err);
+        assert.match(result, /\/\d+\/testAltEndpointQueue/);
+      }
+    }
+  
+  }
+}).addBatch({
+  'A queue' : {
+    topic: new SQS(keys.id, keys.secret, {region: REGION}),
 
     'when retreiving a queue url': {
       topic: function(sqs) {
@@ -84,7 +104,7 @@ vows.describe('Simple Queue Service').addBatch({
     }
   },
   'A message' : {
-    topic: new SQS(keys.id, keys.secret),
+    topic: new SQS(keys.id, keys.secret, {region: REGION}),
 
     'when sending a message' : {
       topic: getQualifiedQueue('testQueue', function () {
@@ -109,7 +129,7 @@ vows.describe('Simple Queue Service').addBatch({
   }
 }).addBatch({
   'A message' : {
-    topic: new SQS(keys.id, keys.secret),
+    topic: new SQS(keys.id, keys.secret, {region: REGION}),
 
     'when receiving a message' : {
       topic: getQualifiedQueue('testQueue', function () {
@@ -138,7 +158,7 @@ vows.describe('Simple Queue Service').addBatch({
   }
 }).addBatch({
   'A batch message' : {
-    topic: new SQS(keys.id, keys.secret),
+    topic: new SQS(keys.id, keys.secret, {region: REGION}),
 
     'when sending a batch of messages' : {
       topic: getQualifiedQueue('testQueue', function () {
@@ -160,7 +180,7 @@ vows.describe('Simple Queue Service').addBatch({
   }
 }).addBatch({
   'A queue' : {
-    topic: new SQS(keys.id, keys.secret),
+    topic: new SQS(keys.id, keys.secret, {region: REGION}),
 
     'when requesting all queue attributes': {
       topic: getQualifiedQueue('testQueue', function () {
@@ -191,7 +211,7 @@ vows.describe('Simple Queue Service').addBatch({
   }
 }).addBatch({
   'A queue' : {
-    topic: new SQS(keys.id, keys.secret),
+    topic: new SQS(keys.id, keys.secret, {region: REGION}),
 
     'when deleting a queue': {
       topic: getQualifiedQueue('testQueue', function () {
@@ -204,6 +224,15 @@ vows.describe('Simple Queue Service').addBatch({
     },
     'when deleting another queue': {
       topic: getQualifiedQueue('testTimeoutQueue', function () {
+        this.sqs.deleteQueue(this.queue, this.callback);
+      }),
+
+      'results in success': function (err, result) {
+        assert.isNull(err);
+      }
+    },
+    'when deleting the alternate queue': {
+      topic: getQualifiedQueue('testAltEndpointQueue', function () {
         this.sqs.deleteQueue(this.queue, this.callback);
       }),
 


### PR DESCRIPTION
This fixes issue #4 by adding a bool option to the `SQS` constructor, `opts.altEndPoint`.

If `opts.altEndPoint` is truthy:
- the alternate sqs hostname pattern `[region.]queue.amazonaws.com` will be used

If `opts.altEndPoint` is falsy (=or omitted) :
- the current hostname pattern `sqs.[region].amazonaws.com` will be used.

See http://docs.aws.amazon.com/AWSSimpleQueueService/2009-02-01/SQSDeveloperGuide/index.html?endpoints.html for details.

I have ran the test suite against all current regions, and it works for all of them, including `ap-northeast-1` and `us-west-2`, which are undocumented in the url above.

Please note that you can always mix usage of endpoints, eg: you can delete a or send messages to a queue over the alternate endpoint hostname that was created using the current endpoint hostname.
